### PR TITLE
Add null check for zone in AppendFertileCount

### DIFF
--- a/Source/ZoneSizeCount.cs
+++ b/Source/ZoneSizeCount.cs
@@ -34,7 +34,7 @@ namespace TD_Enhancement_Pack
 
 		public static string AppendFertileCount(string baseString, Zone_Growing zone)
 		{
-			if (!Mod.settings.showGrowingFertilitySize) return baseString;
+			if (!Mod.settings.showGrowingFertilitySize || zone is null) return baseString;
 
 			float fertCount = zone.CellCount + 
 				zone.GetPlantDefToGrow().plant.fertilitySensitivity


### PR DESCRIPTION
In a heavily modded game, I occasionally hit errors here - 

```
System.NullReferenceException: Object reference not set to an instance of an object
[Ref EC88894C]
  at TD_Enhancement_Pack.ZoneGrowingSizeCount.AppendFertileCount (System.String baseString, RimWorld.Zone_Growing zone) [0x00032] in <1a62ba8835224f93a79c6a48abf42a61>:0 
  at RimWorld.Zone_Growing.GetInspectString () [0x00009] in <24d25868955f4df08b02c73b55f389fe>:0 
    - TRANSPILER Uuugggg.rimworld.TD_Enhancement_Pack.main: IEnumerable`1 TD_Enhancement_Pack.ZoneGrowingSizeCount:Transpiler(IEnumerable`1 instructions)
    - POSTFIX owlchemist.smartfarming: String SmartFarming.Patch_GetInspectString:Postfix(String __result, Zone_Growing __instance)
    - POSTFIX Helixien.ReGrowthCore: String ReGrowthCore.Patch_GetInspectString:Postfix(String __result, Zone __instance)
  at RimWorld.InspectPaneFiller.DrawInspectStringFor (Verse.ISelectable sel, UnityEngine.Rect rect) [0x00000] in <24d25868955f4df08b02c73b55f389fe>:0 
```
This PR guards the transpiled function in case a null zone sneaks in.