### PR TITLE
make the areas edit window wider if there are options to hide areas

### DIFF
--- a/Source/AreaEditable.cs
+++ b/Source/AreaEditable.cs
@@ -49,6 +49,20 @@ namespace TD_Enhancement_Pack
 	*/
 
 
+	//public override Vector2 InitialSize => new Vector2(550f, 400f);
+	[HarmonyPatch(typeof(Dialog_ManageAreas))]
+	[HarmonyPatch("InitialSize")]
+	[HarmonyPatch(MethodType.Getter)]
+	static class Dialog_ManageAreas_InitialSize_Patch
+	{
+		public static Vector2 Postfix(Vector2 result)
+		{
+			if (Mod.settings.areaForTypes)
+				result.x += 25;
+			return result;
+		}
+	}
+
 	//public override void DoWindowContents(Rect inRect)
 	[HarmonyPatch(typeof(Dialog_ManageAreas))]
 	[HarmonyPatch("DoWindowContents")]


### PR DESCRIPTION
Probably a result of my #7, if there were so many areas that the scrollbar was shown, it was hiding the 'down' move button.